### PR TITLE
Fix activemq.xml "not allowed" attribute  and bump version to 5.9.0. 

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@
 #
 
 default['activemq']['mirror']  = 'http://apache.mirrors.tds.net'
-default['activemq']['version'] = '5.8.0'
+default['activemq']['version'] = '5.9.0'
 default['activemq']['home']  = '/opt'
 default['activemq']['wrapper']['max_memory'] = '1024'
 default['activemq']['wrapper']['useDedicatedTaskRunner'] = 'true'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,3 +25,7 @@ default['activemq']['wrapper']['useDedicatedTaskRunner'] = 'true'
 
 default['activemq']['enable_stomp'] = true
 default['activemq']['use_default_config'] = false
+
+# The original behavior was true, but that breaks recent ActiveMQs (5.9.0). 
+# Default should be false to let newer versions work by default.
+default['activemq']['destroy_app_context_on_stop'] = false

--- a/templates/default/activemq.xml.erb
+++ b/templates/default/activemq.xml.erb
@@ -32,7 +32,9 @@
     <!--
         The <broker> element is used to configure the ActiveMQ broker.
     -->
-    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.base}/data" destroyApplicationContextOnStop="true">
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.base}/data" <% if node['activemq']['destroy_app_context_on_stop'] -%>
+                              destroyApplicationContextOnStop="true"
+                            <% end %> >
 
         <!--
 			      For better performances use VM cursor and small memory limit.


### PR DESCRIPTION
### Problem:

In newer ActiveMQ brokers, the **destroyApplicationContextOnStop** attribute seems to have been removed from the <broker> tag in activemq.xml. It causes the exception pasted below upon startup, and the broker will not start. I'm not sure as of which version of ActiveMQ this went away, but it's definitely broken in 5.9.0. 


### Solution:

This PR makes the attribute optional but defaults it to "not present" for compatibility with current and later versions of the broker. It also bumps the default version to 5.9.0, which is current stable. 

A default attribute was added:

> default['activemq']['destroy_app_context_on_stop'] = false

Setting it to "true" would bring back the original behavior. I normally would have done it the opposite way to preserve the status quo, but that would break it for every future version of ActiveMQ. 

### Exception in activemq.log:

**Caused by: org.xml.sax.SAXParseException; lineNumber: 37; columnNumber: 31; cvc-complex-type.3.2.2: Attribute 'destroyApplicationContextOnStop' is not allowed to appear in element 'broker'.**
        at com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.createSAXParseException(ErrorHandlerWrapper.java:198)
        at com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.error(ErrorHandlerWrapper.java:134)
        at com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(XMLErrorReporter.java:437)
        at com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(XMLErrorReporter.java:368)
        at com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(XMLErrorReporter.java:325)
        at com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator$XSIErrorReporter.reportError(XMLSchemaValidator.java:458)
        at com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.reportSchemaError(XMLSchemaValidator.java:3237)
        at com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.processAttributes(XMLSchemaValidator.java:2714)
        at com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.handleStartElement(XMLSchemaValidator.java:2056)
        at com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.startElement(XMLSchemaValidator.java:746)
        at com.sun.org.apache.xerces.internal.impl.XMLNSDocumentScannerImpl.scanStartElement(XMLNSDocumentScannerImpl.java:378)
        at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl$FragmentContentDriver.next(XMLDocumentFragmentScannerImpl.java:2778)
        at com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl.next(XMLDocumentScannerImpl.java:606)
        at com.sun.org.apache.xerces.internal.impl.XMLNSDocumentScannerImpl.next(XMLNSDocumentScannerImpl.java:117)
        at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanDocument(XMLDocumentFragmentScannerImpl.java:510)
        at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:848)
        at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:777)
        at com.sun.org.apache.xerces.internal.parsers.XMLParser.parse(XMLParser.java:141)
        at com.sun.org.apache.xerces.internal.parsers.DOMParser.parse(DOMParser.java:243)
        at com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderImpl.parse(DocumentBuilderImpl.java:347)
        at org.springframework.beans.factory.xml.DefaultDocumentLoader.loadDocument(DefaultDocumentLoader.java:75)
        at org.springframework.beans.factory.xml.XmlBeanDefinitionReader.doLoadBeanDefinitions(XmlBeanDefinitionReader.java:388)
        ... 31 more
