### PR TITLE
COOK-4711 Remove check for 'vagrant' user as that depends on the kitchen driver

### DIFF
--- a/test/integration/default/serverspec/localhost/activemq_spec.rb
+++ b/test/integration/default/serverspec/localhost/activemq_spec.rb
@@ -2,10 +2,6 @@ require 'spec_helper'
 
 describe 'ActiveMQ server' do
 
-  it 'should have a vagrant user' do
-    expect(user('vagrant')).to exist
-  end
-
   it 'should be running the activemq server' do
     expect(service('activemq')).to be_running
     expect(service('activemq')).to be_enabled


### PR DESCRIPTION
in use and doesn't actually have anything to do with activemq running.