### PR TITLE
Adding global amq distribution service switch

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,5 +23,6 @@ default['activemq']['home']  = '/opt'
 default['activemq']['wrapper']['max_memory'] = '1024'
 default['activemq']['wrapper']['useDedicatedTaskRunner'] = 'true'
 
+default['activemq']['enabled'] = true
 default['activemq']['enable_stomp'] = true
 default['activemq']['use_default_config'] = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -64,6 +64,7 @@ end
 service 'activemq' do
   supports :restart => true, :status => true
   action   [:enable, :start]
+  only_if { node['activemq']['enabled'] }
 end
 
 # symlink so the default wrapper.conf can find the native wrapper library
@@ -80,5 +81,5 @@ end
 template "#{activemq_home}/bin/linux/wrapper.conf" do
   source   'wrapper.conf.erb'
   mode     '0644'
-  notifies :restart, 'service[activemq]'
+  notifies :restart, 'service[activemq]' if node['activemq']['enabled']
 end


### PR DESCRIPTION
This a very trivial mod allowing us to disable main ActiveMQ service when we're working with instances only.
In this case, we don't want to see the main distribution to be spawned.

Default option is true, so the service is still started to keep current behaviour.

Thanks