### PR TITLE
Optionally allow java to not be managed via the java cookbook.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Attributes
 - `node['activemq']['enable_stomp']` - Flag that decides whether or not to use stomp. Note: This is
 only used when `use_default_config` attribute is true.
 - `node['activemq']['use_default_config']` - Flag that allows the option to use a basic configuration file
+- `node['activemq']['install_java']` - Whether or not to use the Java community cookbook to install Java. Defaults to `true`.
 
 
 Usage

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,3 +25,4 @@ default['activemq']['wrapper']['useDedicatedTaskRunner'] = 'true'
 
 default['activemq']['enable_stomp'] = true
 default['activemq']['use_default_config'] = false
+default['activemq']['install_java'] = true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe 'java::default'
+include_recipe 'java::default' if node['activemq']['install_java']
 
 tmp = Chef::Config[:file_cache_path]
 version = node['activemq']['version']


### PR DESCRIPTION
Allows for conditional exclusion of the java cookbook's default recipe for those of us who use other methods to configure our java environments. 