### PR TITLE
Add default recipe to metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,3 +11,5 @@ version          '1.3.3'
 end
 
 depends 'java', '~> 1.13'
+
+recipe 'activemq::default', 'Installs ActiveMQ and sets it up as a service.'


### PR DESCRIPTION
Add activemq::default to metadata.rb, this will allow the recipe show up in the RightScale dashboard which requires this metadata for each recipe in a Chef cookbook.