### PR TITLE
option to ignore wrapper.conf

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -80,5 +80,6 @@ end
 template "#{activemq_home}/bin/linux/wrapper.conf" do
   source   'wrapper.conf.erb'
   mode     '0644'
+  only_if  { node['activemq']['use_default_config'] }
   notifies :restart, 'service[activemq]'
 end


### PR DESCRIPTION
If the user wants to their own activemq.xml config, they'll probably want to do their own wrapper.conf. I know I certainly do ;)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/opscode-cookbooks/activemq/27)
<!-- Reviewable:end -->
